### PR TITLE
add public REST client token cache

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,7 @@
       <directory>tests</directory>
     </include>
   </source>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+  </extensions>
 </phpunit>

--- a/src/PublicRestApi/Connection.php
+++ b/src/PublicRestApi/Connection.php
@@ -17,13 +17,19 @@ class Connection implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
+    public const CACHE_SUBNAMESPACE = 'DbpCampusonlineApiPublicRestApiConnection';
+    public const DEFAULT_TOKEN_REFRESH_INTERVAL_SECS = self::DEFAULT_TOKEN_VALIDITY_SECS - self::REFRESH_TOKEN_SAFETY_MARGIN_SECS;
+
+    private const DEFAULT_TOKEN_VALIDITY_SECS = 300;
+    private const REFRESH_TOKEN_SAFETY_MARGIN_SECS = 30;
+
     private ?object $clientHandler = null;
 
     private ?string $token = null;
     private ?\DateTimeImmutable $requestNewTokenBefore = null;
 
     private ?CacheItemPoolInterface $cachePool = null;
-    private int $fallbackCacheTTL = 300;
+    private int $fallbackCacheTTL = self::DEFAULT_TOKEN_REFRESH_INTERVAL_SECS;
 
     public function __construct(
         private string $baseUrl,
@@ -42,7 +48,7 @@ class Connection implements LoggerAwareInterface
 
     public function setCache(
         ?CacheItemPoolInterface $cachePool,
-        int $fallbackTTL = 300
+        int $fallbackTTL = self::DEFAULT_TOKEN_REFRESH_INTERVAL_SECS
     ): void {
         $this->cachePool = $cachePool;
         $this->fallbackCacheTTL = $fallbackTTL;
@@ -158,23 +164,21 @@ class Connection implements LoggerAwareInterface
 
             $this->token = $token;
 
-            $expiresIn = (int) ($tokenData['expires_in'] ?? 0);
-            $getNewTokenInSecs = $expiresIn > 0
-                ? $expiresIn - 30
-                : $this->fallbackCacheTTL;
-            $getNewTokenInSecs = max(1, $getNewTokenInSecs);
-
-            try {
-                $this->requestNewTokenBefore = (new \DateTimeImmutable())
-                    ->add(new \DateInterval('PT'.$getNewTokenInSecs.'S'));
-            } catch (\Exception) {
-                throw new ApiException('failed to calculate token refresh time');
+            if (null === ($expiresIn = $tokenData['expires_in'] ?? null)) {
+                $getNewTokenInSecs = $this->fallbackCacheTTL;
+            } else {
+                $getNewTokenInSecs = max(0, (int) $expiresIn - self::REFRESH_TOKEN_SAFETY_MARGIN_SECS);
             }
 
-            if ($cacheItem !== null) {
-                $cacheItem->set($this->token);
-                $cacheItem->expiresAfter($getNewTokenInSecs);
-                $cachePool->save($cacheItem);
+            if ($getNewTokenInSecs > 0) {
+                $this->requestNewTokenBefore = (new \DateTimeImmutable())
+                    ->add(new \DateInterval('PT'.$getNewTokenInSecs.'S'));
+
+                if ($cacheItem !== null) {
+                    $cacheItem->set($this->token);
+                    $cacheItem->expiresAfter($getNewTokenInSecs);
+                    $cachePool->save($cacheItem);
+                }
             }
         } catch (GuzzleException $guzzleException) {
             throw ApiException::fromGuzzleException($guzzleException);

--- a/src/PublicRestApi/Connection.php
+++ b/src/PublicRestApi/Connection.php
@@ -23,14 +23,13 @@ class Connection implements LoggerAwareInterface
     private ?\DateTimeImmutable $requestNewTokenBefore = null;
 
     private ?CacheItemPoolInterface $cachePool = null;
-
-    private int $cacheTTL = 0;
+    private int $fallbackCacheTTL = 300;
 
     public function __construct(
         private string $baseUrl,
         private readonly string $clientId,
-        private readonly string $clientSecret)
-    {
+        private readonly string $clientSecret
+    ) {
         if (false === str_ends_with($this->baseUrl, '/')) {
             $this->baseUrl .= '/';
         }
@@ -41,10 +40,12 @@ class Connection implements LoggerAwareInterface
         $this->clientHandler = $handler;
     }
 
-    public function setCache(?CacheItemPoolInterface $cachePool, int $ttl): void
-    {
+    public function setCache(
+        ?CacheItemPoolInterface $cachePool,
+        int $fallbackTTL = 300
+    ): void {
         $this->cachePool = $cachePool;
-        $this->cacheTTL = $ttl;
+        $this->fallbackCacheTTL = $fallbackTTL;
     }
 
     public function getClient(): Client
@@ -96,8 +97,11 @@ class Connection implements LoggerAwareInterface
             return $this->token;
         }
 
-        if ($this->cachePool !== null) {
-            $cacheItem = $this->cachePool->getItem($this->getTokenCacheKey());
+        $cachePool = $this->cachePool;
+        $cacheItem = null;
+
+        if ($cachePool !== null) {
+            $cacheItem = $cachePool->getItem($this->getTokenCacheKey());
 
             if ($cacheItem->isHit()) {
                 $cachedToken = $cacheItem->get();
@@ -155,7 +159,9 @@ class Connection implements LoggerAwareInterface
             $this->token = $token;
 
             $expiresIn = (int) ($tokenData['expires_in'] ?? 0);
-            $getNewTokenInSecs = $expiresIn > 0 ? $expiresIn - 30 : $this->cacheTTL;
+            $getNewTokenInSecs = $expiresIn > 0
+                ? $expiresIn - 30
+                : $this->fallbackCacheTTL;
             $getNewTokenInSecs = max(1, $getNewTokenInSecs);
 
             try {
@@ -165,11 +171,10 @@ class Connection implements LoggerAwareInterface
                 throw new ApiException('failed to calculate token refresh time');
             }
 
-            if ($this->cachePool !== null) {
-                $cacheItem = $this->cachePool->getItem($this->getTokenCacheKey());
+            if ($cacheItem !== null) {
                 $cacheItem->set($this->token);
                 $cacheItem->expiresAfter($getNewTokenInSecs);
-                $this->cachePool->save($cacheItem);
+                $cachePool->save($cacheItem);
             }
         } catch (GuzzleException $guzzleException) {
             throw ApiException::fromGuzzleException($guzzleException);

--- a/src/PublicRestApi/Connection.php
+++ b/src/PublicRestApi/Connection.php
@@ -72,6 +72,14 @@ class Connection implements LoggerAwareInterface
         $this->requestNewTokenBefore = $requestNewTokenBefore;
     }
 
+    /**
+     * @internal
+     */
+    public function getTokenForTesting(): string
+    {
+        return $this->getToken();
+    }
+
     private function getTokenCacheKey(): string
     {
         return Tools::escapeCacheKey('client-tokens/'.$this->clientId);

--- a/src/PublicRestApi/Connection.php
+++ b/src/PublicRestApi/Connection.php
@@ -9,6 +9,7 @@ use Dbp\CampusonlineApi\Rest\Tools;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\HandlerStack;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 
@@ -20,6 +21,10 @@ class Connection implements LoggerAwareInterface
 
     private ?string $token = null;
     private ?\DateTimeImmutable $requestNewTokenBefore = null;
+
+    private ?CacheItemPoolInterface $cachePool = null;
+
+    private int $cacheTTL = 0;
 
     public function __construct(
         private string $baseUrl,
@@ -34,6 +39,12 @@ class Connection implements LoggerAwareInterface
     public function setClientHandler(?object $handler): void
     {
         $this->clientHandler = $handler;
+    }
+
+    public function setCache(?CacheItemPoolInterface $cachePool, int $ttl): void
+    {
+        $this->cachePool = $cachePool;
+        $this->cacheTTL = $ttl;
     }
 
     public function getClient(): Client
@@ -61,60 +72,99 @@ class Connection implements LoggerAwareInterface
         $this->requestNewTokenBefore = $requestNewTokenBefore;
     }
 
+    private function getTokenCacheKey(): string
+    {
+        return Tools::escapeCacheKey('client-tokens/'.$this->clientId);
+    }
+
     /**
      * @throws ApiException
      */
     private function getToken(): string
     {
-        if ($this->token === null
-            || $this->requestNewTokenBefore === null
-            || (new \DateTimeImmutable()) >= $this->requestNewTokenBefore) {
-            $stack = HandlerStack::create($this->clientHandler);
-            $client_options = [
-                'handler' => $stack,
-            ];
-            if ($this->logger !== null) {
-                $stack->push(Tools::createLoggerMiddleware($this->logger));
+        if ($this->token !== null
+            && $this->requestNewTokenBefore !== null
+            && (new \DateTimeImmutable()) < $this->requestNewTokenBefore) {
+            return $this->token;
+        }
+
+        if ($this->cachePool !== null) {
+            $cacheItem = $this->cachePool->getItem($this->getTokenCacheKey());
+
+            if ($cacheItem->isHit()) {
+                $cachedToken = $cacheItem->get();
+
+                if (is_string($cachedToken) && $cachedToken !== '') {
+                    $this->token = $cachedToken;
+
+                    return $this->token;
+                }
             }
-            $client = new Client($client_options);
+        }
+
+        $stack = HandlerStack::create($this->clientHandler);
+        $clientOptions = [
+            'handler' => $stack,
+        ];
+
+        if ($this->logger !== null) {
+            $stack->push(Tools::createLoggerMiddleware($this->logger));
+        }
+
+        $client = new Client($clientOptions);
+
+        try {
+            $authServerUrl = Tools::decodeJsonResponse(
+                $client->get($this->baseUrl.'/co/public/api/environment')
+            )['authServerUrl'] ?? null;
+
+            if ($authServerUrl === null) {
+                throw new ApiException('auth server url not found in environment');
+            }
+
+            $tokenEndpoint = Tools::decodeJsonResponse(
+                $client->get($authServerUrl.'/.well-known/openid-configuration')
+            )['token_endpoint'] ?? null;
+
+            if ($tokenEndpoint === null) {
+                throw new ApiException('token endpoint not found in auth server response');
+            }
+
+            $tokenData = Tools::decodeJsonResponse(
+                $client->post($tokenEndpoint, [
+                    'form_params' => [
+                        'client_id' => $this->clientId,
+                        'client_secret' => $this->clientSecret,
+                        'grant_type' => 'client_credentials',
+                    ],
+                ])
+            );
+
+            if (null === ($token = $tokenData['access_token'] ?? null)) {
+                throw new ApiException('access token not found in auth server response');
+            }
+
+            $this->token = $token;
+
+            $expiresIn = (int) ($tokenData['expires_in'] ?? 0);
+            $getNewTokenInSecs = $expiresIn > 0 ? $expiresIn - 30 : $this->cacheTTL;
+            $getNewTokenInSecs = max(1, $getNewTokenInSecs);
 
             try {
-                $authServerUrl = Tools::decodeJsonResponse(
-                    $client->get($this->baseUrl.'/co/public/api/environment'))['authServerUrl'] ?? null;
-                if ($authServerUrl === null) {
-                    throw new ApiException('auth server url not found in environment');
-                }
-
-                $tokenEndpoint = Tools::decodeJsonResponse(
-                    $client->get($authServerUrl.'/.well-known/openid-configuration'))['token_endpoint'] ?? null;
-                if ($tokenEndpoint === null) {
-                    throw new ApiException('token endpoint not found in auth server response');
-                }
-
-                $tokenData = Tools::decodeJsonResponse(
-                    $client->post($tokenEndpoint, [
-                        'form_params' => [
-                            'client_id' => $this->clientId,
-                            'client_secret' => $this->clientSecret,
-                            'grant_type' => 'client_credentials',
-                        ],
-                    ]));
-
-                if (null === ($token = $tokenData['access_token'] ?? null)) {
-                    throw new ApiException('access token not found in auth server response');
-                }
-                $this->token = $token;
-
-                $getNewTokenInSecs = (int) ($tokenData['expires_in'] ?? 0) - 30;
-                try {
-                    $this->requestNewTokenBefore = (new \DateTimeImmutable())
-                        ->add(new \DateInterval('PT'.$getNewTokenInSecs.'S'));
-                } catch (\Exception) {
-                    throw new ApiException('failed to calculate token refresh time');
-                }
-            } catch (GuzzleException $guzzleException) {
-                throw ApiException::fromGuzzleException($guzzleException);
+                $this->requestNewTokenBefore = (new \DateTimeImmutable())
+                    ->add(new \DateInterval('PT'.$getNewTokenInSecs.'S'));
+            } catch (\Exception) {
+                throw new ApiException('failed to calculate token refresh time');
             }
+
+            if ($this->cachePool !== null) {
+                $cacheItem = $this->cachePool->getItem($this->getTokenCacheKey());
+                $cacheItem->set($this->token);
+                $cacheItem->expiresAfter($getNewTokenInSecs);
+                $this->cachePool->save($cacheItem);
+            }
+        } catch (GuzzleException $guzzleException) {
+            throw ApiException::fromGuzzleException($guzzleException);
         }
 
         return $this->token;

--- a/src/Rest/Tools.php
+++ b/src/Rest/Tools.php
@@ -164,4 +164,14 @@ class Tools
 
         return new ApiException($guzzleException->getMessage(), $guzzleException->getCode(), $response !== null);
     }
+
+    /**
+     * Escape a cache key string to be valid as a Symfony cache key.
+     */
+    public static function escapeCacheKey(string $input): string
+    {
+        // Always append a '.' since empty strings are also not allowed.
+        // For what isn't allowed, see ItemInterface::RESERVED_CHARACTERS
+        return rawurlencode($input.'.');
+    }
 }

--- a/tests/PublicRestApi/ConnectionTest.php
+++ b/tests/PublicRestApi/ConnectionTest.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Dbp\CampusonlineApi\Tests\PublicRestApi;
 
 use Dbp\CampusonlineApi\PublicRestApi\Connection;
-use Dbp\CampusonlineApi\Rest\Tools;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use Psr\Cache\CacheItemInterface;
-use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -18,44 +15,6 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 #[TimeSensitive(ArrayAdapter::class)]
 class ConnectionTest extends TestCase
 {
-    public function testReusesFetchedTokenFromCacheAcrossConnectionInstances(): void
-    {
-        $cacheItem = new InMemoryCacheItem(null, false);
-        $cachePool = new InMemoryCachePool($cacheItem);
-
-        $firstHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', 120));
-
-        $firstConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
-        $firstConnection->setClientHandler($firstHandler);
-        $firstConnection->setCache($cachePool, 999);
-
-        $firstClient = $firstConnection->getClient();
-
-        self::assertSame('Bearer shared-cache-token', $firstClient->getConfig('headers')['Authorization']);
-        self::assertSame('shared-cache-token', $cacheItem->value);
-        self::assertSame(90, $cacheItem->expiresAfterValue);
-        self::assertSame(1, $cachePool->saveCalls);
-        self::assertSame(Tools::escapeCacheKey('client-tokens/client-id'), $cachePool->lastKey);
-
-        // After the first connection, the token has been stored in the shared cache.
-        // Mark the fake cache item as a cache hit for the second connection.
-        $cacheItem->hit = true;
-
-        $secondConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
-        $secondConnection->setCache($cachePool, 999);
-
-        // If the second connection tries to fetch a token from the auth server,
-        // this empty handler will fail. Therefore the token must come from cache.
-        $secondConnection->setClientHandler(new MockHandler([]));
-
-        $secondClient = $secondConnection->getClient();
-
-        self::assertSame('Bearer shared-cache-token', $secondClient->getConfig('headers')['Authorization']);
-        self::assertSame(3, $cachePool->getItemCalls);
-        self::assertSame(1, $cachePool->saveCalls);
-        self::assertSame(Tools::escapeCacheKey('client-tokens/client-id'), $cachePool->lastKey);
-    }
-
     public function testTokenCacheItemPool(): void
     {
         ClockMock::withClockMock(true);
@@ -64,169 +23,125 @@ class ConnectionTest extends TestCase
         $tokenExpiresIn = 120;
         $cacheItemExpiresIn = $tokenExpiresIn - 30;
 
-        // initially, the token must be requested from the auth server:
-        $firstConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
-        $mockHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', $tokenExpiresIn));
+        // Initially, the token must be requested from the auth server.
+        $firstConnection = new Connection(
+            'https://api.example.invalid',
+            'client-id',
+            'secret'
+        );
+        $mockHandler = new MockHandler(
+            self::getMockAuthServerResponses(
+                'shared-cache-token',
+                $tokenExpiresIn
+            )
+        );
         $firstConnection->setClientHandler($mockHandler);
         $firstConnection->setCache($cachePool, 999);
 
-        self::assertSame('shared-cache-token', $firstConnection->getTokenForTesting());
-        self::assertSame(0, $mockHandler->count()); // assert that mock API responses have been consumed
+        self::assertSame(
+            'shared-cache-token',
+            $firstConnection->getTokenForTesting()
+        );
+        self::assertSame(0, $mockHandler->count());
 
-        // the cache item must be valid (no more API calls must be made):
+        // The cache item must still be valid, so no API request is required.
         ClockMock::sleep($cacheItemExpiresIn - 1);
-        $secondConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+
+        $secondConnection = new Connection(
+            'https://api.example.invalid',
+            'client-id',
+            'secret'
+        );
         $secondConnection->setCache($cachePool, 999);
 
-        self::assertSame('shared-cache-token', $secondConnection->getTokenForTesting());
+        self::assertSame(
+            'shared-cache-token',
+            $secondConnection->getTokenForTesting()
+        );
 
-        // the cache item must be expired and the token requested from the auth server:
+        // The cache item has expired, so a new token must be requested.
         ClockMock::sleep(2);
-        $thirdConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
-        $mockHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', 120));
+
+        $thirdConnection = new Connection(
+            'https://api.example.invalid',
+            'client-id',
+            'secret'
+        );
+        $mockHandler = new MockHandler(
+            self::getMockAuthServerResponses(
+                'shared-cache-token',
+                $tokenExpiresIn
+            )
+        );
         $thirdConnection->setClientHandler($mockHandler);
         $thirdConnection->setCache($cachePool, 999);
 
-        self::assertSame('shared-cache-token', $thirdConnection->getTokenForTesting());
-        self::assertSame(0, $mockHandler->count()); // assert that mock API responses have been consumed
+        self::assertSame(
+            'shared-cache-token',
+            $thirdConnection->getTokenForTesting()
+        );
+        self::assertSame(0, $mockHandler->count());
     }
 
     public function testTokenRequestCache(): void
     {
-        // initially, the token must be requested from the auth server:
-        $connection = new Connection('https://api.example.invalid', 'client-id', 'secret');
-        $mockHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', 120));
+        // Initially, the token must be requested from the auth server.
+        $connection = new Connection(
+            'https://api.example.invalid',
+            'client-id',
+            'secret'
+        );
+        $mockHandler = new MockHandler(
+            self::getMockAuthServerResponses(
+                'shared-cache-token',
+                120
+            )
+        );
         $connection->setClientHandler($mockHandler);
-        self::assertSame('shared-cache-token', $connection->getTokenForTesting());
-        self::assertSame(0, $mockHandler->count()); // assert that mock API responses have been consumed
 
-        // request cached token from memory must be used (no more API calls must be made):
-        self::assertSame('shared-cache-token', $connection->getTokenForTesting());
+        self::assertSame(
+            'shared-cache-token',
+            $connection->getTokenForTesting()
+        );
+        self::assertSame(0, $mockHandler->count());
+
+        // The token must now be reused from the in-memory request cache.
+        self::assertSame(
+            'shared-cache-token',
+            $connection->getTokenForTesting()
+        );
     }
 
+    /**
+     * @return Response[]
+     */
     private static function getMockAuthServerResponses(
-        string $token = 'token', int $expiresIn = 300): array
-    {
+        string $token = 'token',
+        int $expiresIn = 300
+    ): array {
         return [
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'authServerUrl' => 'https://auth.example.invalid',
-            ], JSON_THROW_ON_ERROR)),
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'token_endpoint' => 'https://auth.example.invalid/token',
-            ], JSON_THROW_ON_ERROR)),
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'access_token' => $token,
-                'expires_in' => $expiresIn,
-            ], JSON_THROW_ON_ERROR)),
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'authServerUrl' => 'https://auth.example.invalid',
+                ], JSON_THROW_ON_ERROR)
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'token_endpoint' => 'https://auth.example.invalid/token',
+                ], JSON_THROW_ON_ERROR)
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'access_token' => $token,
+                    'expires_in' => $expiresIn,
+                ], JSON_THROW_ON_ERROR)
+            ),
         ];
-    }
-}
-
-final class InMemoryCacheItem implements CacheItemInterface
-{
-    public mixed $value;
-    public bool $hit;
-    public ?int $expiresAfterValue = null;
-
-    public function __construct(mixed $value, bool $hit)
-    {
-        $this->value = $value;
-        $this->hit = $hit;
-    }
-
-    public function getKey(): string
-    {
-        return 'token-key';
-    }
-
-    public function get(): mixed
-    {
-        return $this->value;
-    }
-
-    public function isHit(): bool
-    {
-        return $this->hit;
-    }
-
-    public function set(mixed $value): static
-    {
-        $this->value = $value;
-
-        return $this;
-    }
-
-    public function expiresAt(?\DateTimeInterface $expiration): static
-    {
-        return $this;
-    }
-
-    public function expiresAfter(int|\DateInterval|null $time): static
-    {
-        if (is_int($time)) {
-            $this->expiresAfterValue = $time;
-        }
-
-        return $this;
-    }
-}
-final class InMemoryCachePool implements CacheItemPoolInterface
-{
-    public int $getItemCalls = 0;
-    public int $saveCalls = 0;
-    public ?string $lastKey = null;
-
-    public function __construct(private InMemoryCacheItem $item)
-    {
-    }
-
-    public function getItem(string $key): CacheItemInterface
-    {
-        ++$this->getItemCalls;
-        $this->lastKey = $key;
-
-        return $this->item;
-    }
-
-    public function getItems(array $keys = []): iterable
-    {
-        return [$this->item];
-    }
-
-    public function hasItem(string $key): bool
-    {
-        return $this->item->isHit();
-    }
-
-    public function clear(): bool
-    {
-        return true;
-    }
-
-    public function deleteItem(string $key): bool
-    {
-        return true;
-    }
-
-    public function deleteItems(array $keys): bool
-    {
-        return true;
-    }
-
-    public function save(CacheItemInterface $item): bool
-    {
-        ++$this->saveCalls;
-
-        return true;
-    }
-
-    public function saveDeferred(CacheItemInterface $item): bool
-    {
-        return true;
-    }
-
-    public function commit(): bool
-    {
-        return true;
     }
 }

--- a/tests/PublicRestApi/ConnectionTest.php
+++ b/tests/PublicRestApi/ConnectionTest.php
@@ -36,7 +36,7 @@ class ConnectionTest extends TestCase
             )
         );
         $firstConnection->setClientHandler($mockHandler);
-        $firstConnection->setCache($cachePool, 999);
+        $firstConnection->setCache($cachePool);
 
         self::assertSame(
             'shared-cache-token',
@@ -52,7 +52,7 @@ class ConnectionTest extends TestCase
             'client-id',
             'secret'
         );
-        $secondConnection->setCache($cachePool, 999);
+        $secondConnection->setCache($cachePool);
 
         self::assertSame(
             'shared-cache-token',
@@ -74,7 +74,7 @@ class ConnectionTest extends TestCase
             )
         );
         $thirdConnection->setClientHandler($mockHandler);
-        $thirdConnection->setCache($cachePool, 999);
+        $thirdConnection->setCache($cachePool);
 
         self::assertSame(
             'shared-cache-token',

--- a/tests/PublicRestApi/ConnectionTest.php
+++ b/tests/PublicRestApi/ConnectionTest.php
@@ -11,7 +11,11 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
+#[TimeSensitive(ArrayAdapter::class)]
 class ConnectionTest extends TestCase
 {
     public function testReusesFetchedTokenFromCacheAcrossConnectionInstances(): void
@@ -19,18 +23,7 @@ class ConnectionTest extends TestCase
         $cacheItem = new InMemoryCacheItem(null, false);
         $cachePool = new InMemoryCachePool($cacheItem);
 
-        $firstHandler = new MockHandler([
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'authServerUrl' => 'https://auth.example.invalid',
-            ], JSON_THROW_ON_ERROR)),
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'token_endpoint' => 'https://auth.example.invalid/token',
-            ], JSON_THROW_ON_ERROR)),
-            new Response(200, ['Content-Type' => 'application/json'], json_encode([
-                'access_token' => 'shared-cache-token',
-                'expires_in' => 120,
-            ], JSON_THROW_ON_ERROR)),
-        ]);
+        $firstHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', 120));
 
         $firstConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
         $firstConnection->setClientHandler($firstHandler);
@@ -61,6 +54,71 @@ class ConnectionTest extends TestCase
         self::assertSame(3, $cachePool->getItemCalls);
         self::assertSame(1, $cachePool->saveCalls);
         self::assertSame(Tools::escapeCacheKey('client-tokens/client-id'), $cachePool->lastKey);
+    }
+
+    public function testTokenCacheItemPool(): void
+    {
+        ClockMock::withClockMock(true);
+
+        $cachePool = new ArrayAdapter();
+        $tokenExpiresIn = 120;
+        $cacheItemExpiresIn = $tokenExpiresIn - 30;
+
+        // initially, the token must be requested from the auth server:
+        $firstConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+        $mockHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', $tokenExpiresIn));
+        $firstConnection->setClientHandler($mockHandler);
+        $firstConnection->setCache($cachePool, 999);
+
+        self::assertSame('shared-cache-token', $firstConnection->getTokenForTesting());
+        self::assertSame(0, $mockHandler->count()); // assert that mock API responses have been consumed
+
+        // the cache item must be valid (no more API calls must be made):
+        ClockMock::sleep($cacheItemExpiresIn - 1);
+        $secondConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+        $secondConnection->setCache($cachePool, 999);
+
+        self::assertSame('shared-cache-token', $secondConnection->getTokenForTesting());
+
+        // the cache item must be expired and the token requested from the auth server:
+        ClockMock::sleep(2);
+        $thirdConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+        $mockHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', 120));
+        $thirdConnection->setClientHandler($mockHandler);
+        $thirdConnection->setCache($cachePool, 999);
+
+        self::assertSame('shared-cache-token', $thirdConnection->getTokenForTesting());
+        self::assertSame(0, $mockHandler->count()); // assert that mock API responses have been consumed
+    }
+
+    public function testTokenRequestCache(): void
+    {
+        // initially, the token must be requested from the auth server:
+        $connection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+        $mockHandler = new MockHandler(self::getMockAuthServerResponses('shared-cache-token', 120));
+        $connection->setClientHandler($mockHandler);
+        self::assertSame('shared-cache-token', $connection->getTokenForTesting());
+        self::assertSame(0, $mockHandler->count()); // assert that mock API responses have been consumed
+
+        // request cached token from memory must be used (no more API calls must be made):
+        self::assertSame('shared-cache-token', $connection->getTokenForTesting());
+    }
+
+    private static function getMockAuthServerResponses(
+        string $token = 'token', int $expiresIn = 300): array
+    {
+        return [
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'authServerUrl' => 'https://auth.example.invalid',
+            ], JSON_THROW_ON_ERROR)),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'token_endpoint' => 'https://auth.example.invalid/token',
+            ], JSON_THROW_ON_ERROR)),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'access_token' => $token,
+                'expires_in' => $expiresIn,
+            ], JSON_THROW_ON_ERROR)),
+        ];
     }
 }
 

--- a/tests/PublicRestApi/ConnectionTest.php
+++ b/tests/PublicRestApi/ConnectionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\Tests\PublicRestApi;
+
+use Dbp\CampusonlineApi\PublicRestApi\Connection;
+use Dbp\CampusonlineApi\Rest\Tools;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class ConnectionTest extends TestCase
+{
+    public function testReusesFetchedTokenFromCacheAcrossConnectionInstances(): void
+    {
+        $cacheItem = new InMemoryCacheItem(null, false);
+        $cachePool = new InMemoryCachePool($cacheItem);
+
+        $firstHandler = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'authServerUrl' => 'https://auth.example.invalid',
+            ], JSON_THROW_ON_ERROR)),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'token_endpoint' => 'https://auth.example.invalid/token',
+            ], JSON_THROW_ON_ERROR)),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'access_token' => 'shared-cache-token',
+                'expires_in' => 120,
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $firstConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+        $firstConnection->setClientHandler($firstHandler);
+        $firstConnection->setCache($cachePool, 999);
+
+        $firstClient = $firstConnection->getClient();
+
+        self::assertSame('Bearer shared-cache-token', $firstClient->getConfig('headers')['Authorization']);
+        self::assertSame('shared-cache-token', $cacheItem->value);
+        self::assertSame(90, $cacheItem->expiresAfterValue);
+        self::assertSame(1, $cachePool->saveCalls);
+        self::assertSame(Tools::escapeCacheKey('client-tokens/client-id'), $cachePool->lastKey);
+
+        // After the first connection, the token has been stored in the shared cache.
+        // Mark the fake cache item as a cache hit for the second connection.
+        $cacheItem->hit = true;
+
+        $secondConnection = new Connection('https://api.example.invalid', 'client-id', 'secret');
+        $secondConnection->setCache($cachePool, 999);
+
+        // If the second connection tries to fetch a token from the auth server,
+        // this empty handler will fail. Therefore the token must come from cache.
+        $secondConnection->setClientHandler(new MockHandler([]));
+
+        $secondClient = $secondConnection->getClient();
+
+        self::assertSame('Bearer shared-cache-token', $secondClient->getConfig('headers')['Authorization']);
+        self::assertSame(3, $cachePool->getItemCalls);
+        self::assertSame(1, $cachePool->saveCalls);
+        self::assertSame(Tools::escapeCacheKey('client-tokens/client-id'), $cachePool->lastKey);
+    }
+}
+
+final class InMemoryCacheItem implements CacheItemInterface
+{
+    public mixed $value;
+    public bool $hit;
+    public ?int $expiresAfterValue = null;
+
+    public function __construct(mixed $value, bool $hit)
+    {
+        $this->value = $value;
+        $this->hit = $hit;
+    }
+
+    public function getKey(): string
+    {
+        return 'token-key';
+    }
+
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    public function isHit(): bool
+    {
+        return $this->hit;
+    }
+
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    public function expiresAt(?\DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    public function expiresAfter(int|\DateInterval|null $time): static
+    {
+        if (is_int($time)) {
+            $this->expiresAfterValue = $time;
+        }
+
+        return $this;
+    }
+}
+final class InMemoryCachePool implements CacheItemPoolInterface
+{
+    public int $getItemCalls = 0;
+    public int $saveCalls = 0;
+    public ?string $lastKey = null;
+
+    public function __construct(private InMemoryCacheItem $item)
+    {
+    }
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        ++$this->getItemCalls;
+        $this->lastKey = $key;
+
+        return $this->item;
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return [$this->item];
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return $this->item->isHit();
+    }
+
+    public function clear(): bool
+    {
+        return true;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return true;
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return true;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        ++$this->saveCalls;
+
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
This PR adds cache support for Public REST client tokens in `Dbp\CampusonlineApi\PublicRestApi\Connection`

* added `setCache(?CacheItemPoolInterface $cachePool, int $ttl)` to `PublicRestApi\Connection`, analog to the existing LegacyWebService connection pattern
* Public REST client-token lookup now checks:

  1. valid in-memory token
  2. PSR6 cache
  3. token endpoint on cache miss
* Newly fetched tokens are stored in the configured cache
* Cache TTL is calculated as `expires_in - 30` seconds, with a min. of 1 second
* If `expires_in` is missing, the fallback TTL passed via `setCache()` is used
* Added `Tools::escapeCacheKey()` and use it for `client-tokens/<client-id>` cache keys
* Added a unit test proving that a token fetched by one `PublicRestApi\Connection` instance is reused by a second fresh `Connection` instance through the same cache instance

How to verify:

* `php -l src/PublicRestApi/Connection.php` passes
* `php -l src/Rest/Tools.php` passes
* `php -l tests/PublicRestApi/ConnectionTest.php` passes
* `vendor/bin/phpunit --filter ConnectionTest` passes
* `composer test` passes
* `composer phpstan` passes

