### PR TITLE
add person type key to person claims resource

### DIFF
--- a/src/PublicRestApi/Persons/PersonClaimsResource.php
+++ b/src/PublicRestApi/Persons/PersonClaimsResource.php
@@ -19,6 +19,8 @@ class PersonClaimsResource extends Resource
     private const TITLE_PREFIX_ATTRIBUTE = 'titlePrefix';
     private const TITLE_SUFFIX_ATTRIBUTE = 'titleSuffix';
     private const GENDER_KEY_ATTRIBUTE = 'genderKey';
+
+    private const PERSON_TYPE_KEY_ATTRIBUTE = 'personTypeKey';
     private const PERSON_GROUPS_ATTRIBUTE = 'personGroups';
     private const ADDRESSES_ATTRIBUTE = 'addresses';
     private const COUNTRY_ATTRIBUTE = 'country';
@@ -101,6 +103,11 @@ class PersonClaimsResource extends Resource
     public function getGenderKey(): ?string
     {
         return $this->resourceData[self::GENDER_KEY_ATTRIBUTE] ?? null;
+    }
+
+    public function getPersonTypeKey(): ?string
+    {
+        return $this->resourceData[self::PERSON_TYPE_KEY_ATTRIBUTE] ?? null;
     }
 
     public function getPersonGroups(): ?array

--- a/tests/PublicRestApi/PersonClaimsApiTest.php
+++ b/tests/PublicRestApi/PersonClaimsApiTest.php
@@ -111,6 +111,7 @@ class PersonClaimsApiTest extends TestCase
         $this->assertSame(null, $result->getTitlePrefix());
         $this->assertSame(null, $result->getTitleSuffix());
         $this->assertSame('W', $result->getGenderKey());
+        $this->assertSame('R', $result->getPersonTypeKey());
         $this->assertSame(['STUDENT', 'EMPLOYEE'], $result->getPersonGroups());
         $this->assertSame(2, $result->getNumAddresses());
         $this->assertSame('AT', $result->getAddressCountry(0));
@@ -157,6 +158,7 @@ class PersonClaimsApiTest extends TestCase
         $personClaimsResource = $resources[0];
         assert($personClaimsResource instanceof PersonClaimsResource);
         $this->assertSame('A3F8B2C9E1D74F6A', $personClaimsResource->getUid());
+        $this->assertSame('R', $personClaimsResource->getPersonTypeKey());
         $this->assertSame('xxxxxxxx==', $result->getNextCursor());
     }
 
@@ -171,5 +173,6 @@ class PersonClaimsApiTest extends TestCase
         $personClaimsResource = $resources[0];
         assert($personClaimsResource instanceof PersonClaimsResource);
         $this->assertSame('A3F8B2C9E1D74F6A', $personClaimsResource->getUid());
+        $this->assertSame('R', $personClaimsResource->getPersonTypeKey());
     }
 }


### PR DESCRIPTION
this PR adds `personTypeKey` to `PersonClaimsResource`

**context:**
- The CO Public REST API already provides `personTypeKey`
- The value is needed downstream as a BasePerson localData attribute to distinguish real persons from "placeholder persons"

**changes:**
- Add `PersonClaimsResource::getPersonTypeKey()`
- Add test assertions for item, cursor-based collection and offset-based collection responses

**verification:**
- `composer phpstan`
- `composer test`
- `composer cs`
