### PR TITLE
add studies to public REST API

### DIFF
--- a/src/PublicRestApi/Studies/Common.php
+++ b/src/PublicRestApi/Studies/Common.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+class Common
+{
+    public const API_PATH = 'co/co-sm-core/study/api';
+}

--- a/src/PublicRestApi/Studies/DegreeProgrammeApi.php
+++ b/src/PublicRestApi/Studies/DegreeProgrammeApi.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+use Dbp\CampusonlineApi\PublicRestApi\AbstractApi;
+use Dbp\CampusonlineApi\PublicRestApi\CursorBasedResourcePage;
+
+class DegreeProgrammeApi extends AbstractApi
+{
+    public const DEGREE_PROGRAMME_UID_QUERY_PARAMETER_NAME = 'degree_programme_uid';
+    private const API_PATH = Common::API_PATH.'/degree-programmes';
+
+    /**
+     * @return iterable<DegreeProgrammeResource>
+     */
+    public function getDegreeProgrammes(array $queryParameters = [], array $options = []): iterable
+    {
+        return $this->getResources(
+            self::API_PATH,
+            DegreeProgrammeResource::class,
+            $queryParameters,
+            $options
+        );
+    }
+
+    /**
+     * @return iterable<DegreeProgrammeResource>
+     */
+    public function getDegreeProgrammesByDegreeProgrammeUids(array $degreeProgrammeUids, array $options = []): iterable
+    {
+        return $this->getDegreeProgrammes([
+            self::DEGREE_PROGRAMME_UID_QUERY_PARAMETER_NAME => $degreeProgrammeUids,
+        ], $options);
+    }
+
+    public function getDegreeProgrammeByUid(string $degreeProgrammeUid, array $queryParameters = []): DegreeProgrammeResource
+    {
+        $resource = $this->getResourceByIdentifier(
+            self::API_PATH,
+            DegreeProgrammeResource::class,
+            $degreeProgrammeUid,
+            $queryParameters
+        );
+        assert($resource instanceof DegreeProgrammeResource);
+
+        return $resource;
+    }
+
+    public function getDegreeProgrammesCursorBased(
+        array $queryParameters = [],
+        ?string $cursor = null,
+        int $maxNumItems = 30,
+        array $options = []
+    ): CursorBasedResourcePage {
+        return $this->getResourcesCursorBased(
+            self::API_PATH,
+            DegreeProgrammeResource::class,
+            $queryParameters,
+            $cursor,
+            $maxNumItems,
+            $options
+        );
+    }
+}

--- a/src/PublicRestApi/Studies/DegreeProgrammeResource.php
+++ b/src/PublicRestApi/Studies/DegreeProgrammeResource.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+use Dbp\CampusonlineApi\PublicRestApi\Resource;
+
+class DegreeProgrammeResource extends Resource
+{
+    private const IDENTIFIER_ATTRIBUTE = 'identifier';
+    private const CURRICULUM_UID_ATTRIBUTE = 'curriculumUid';
+    private const ADMISSION_TYPE_ATTRIBUTE = 'admissionType';
+    private const DEGREE_PROGRAMME_TYPE_ATTRIBUTE = 'degreeProgrammeType';
+    private const INTENDED_DEGREE_ATTRIBUTE = 'intendedDegree';
+    private const SUBJECT_ATTRIBUTE = 'subject';
+    private const PARTIAL_DEGREE_PROGRAMMES_ATTRIBUTE = 'partialDegreeProgrammes';
+    private const CODE_ATTRIBUTE = 'code';
+
+    public function getUid(): ?string
+    {
+        return $this->resourceData[self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getIdentifier(): ?string
+    {
+        return $this->resourceData[self::IDENTIFIER_ATTRIBUTE] ?? null;
+    }
+
+    public function getCurriculumUid(): ?string
+    {
+        return $this->resourceData[self::CURRICULUM_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getAdmissionType(): ?string
+    {
+        return $this->resourceData[self::ADMISSION_TYPE_ATTRIBUTE] ?? null;
+    }
+
+    public function getDegreeProgrammeType(): ?string
+    {
+        return $this->resourceData[self::DEGREE_PROGRAMME_TYPE_ATTRIBUTE] ?? null;
+    }
+
+    public function getIntendedDegreeKey(): ?string
+    {
+        return $this->resourceData[self::INTENDED_DEGREE_ATTRIBUTE][self::KEY_ATTRIBUTE] ?? null;
+    }
+
+    public function getIntendedDegreeName(): ?array
+    {
+        return $this->resourceData[self::INTENDED_DEGREE_ATTRIBUTE][self::NAME_ATTRIBUTE][self::VALUE_ATTRIBUTE] ?? null;
+    }
+
+    public function getSubjectUid(): ?string
+    {
+        return $this->resourceData[self::SUBJECT_ATTRIBUTE][self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getSubjectCode(): ?string
+    {
+        return $this->resourceData[self::SUBJECT_ATTRIBUTE][self::CODE_ATTRIBUTE] ?? null;
+    }
+
+    public function getSubjectName(): ?array
+    {
+        return $this->resourceData[self::SUBJECT_ATTRIBUTE][self::NAME_ATTRIBUTE][self::VALUE_ATTRIBUTE] ?? null;
+    }
+
+    /**
+     * @return PartialDegreeProgrammeResource[]
+     */
+    public function getPartialDegreeProgrammes(): array
+    {
+        $partialDegreeProgrammes = [];
+
+        foreach ($this->resourceData[self::PARTIAL_DEGREE_PROGRAMMES_ATTRIBUTE] ?? [] as $partialDegreeProgrammeData) {
+            if (is_array($partialDegreeProgrammeData)) {
+                $partialDegreeProgrammes[] = new PartialDegreeProgrammeResource($partialDegreeProgrammeData);
+            }
+        }
+
+        return $partialDegreeProgrammes;
+    }
+}

--- a/src/PublicRestApi/Studies/PartialDegreeProgrammeResource.php
+++ b/src/PublicRestApi/Studies/PartialDegreeProgrammeResource.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+use Dbp\CampusonlineApi\PublicRestApi\Resource;
+
+class PartialDegreeProgrammeResource extends Resource
+{
+    private const IDENTIFIER_ATTRIBUTE = 'identifier';
+    private const SUBJECT_ATTRIBUTE = 'subject';
+    private const PROGRAMME_ROLE_ATTRIBUTE = 'programmeRole';
+    private const ORDER_ATTRIBUTE = 'order';
+    private const PARENT_DEGREE_PROGRAMME_UID_ATTRIBUTE = 'parentDegreeProgrammeUid';
+    private const CURRICULUM_UID_ATTRIBUTE = 'curriculumUid';
+    private const CODE_ATTRIBUTE = 'code';
+    private const TYPE_ATTRIBUTE = 'type';
+
+    public function getUid(): ?string
+    {
+        return $this->resourceData[self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getIdentifier(): ?string
+    {
+        return $this->resourceData[self::IDENTIFIER_ATTRIBUTE] ?? null;
+    }
+
+    public function getSubjectUid(): ?string
+    {
+        return $this->resourceData[self::SUBJECT_ATTRIBUTE][self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getSubjectCode(): ?string
+    {
+        return $this->resourceData[self::SUBJECT_ATTRIBUTE][self::CODE_ATTRIBUTE] ?? null;
+    }
+
+    public function getSubjectName(): ?array
+    {
+        return $this->resourceData[self::SUBJECT_ATTRIBUTE][self::NAME_ATTRIBUTE][self::VALUE_ATTRIBUTE] ?? null;
+    }
+
+    public function getProgrammeRoleUid(): ?string
+    {
+        return $this->resourceData[self::PROGRAMME_ROLE_ATTRIBUTE][self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getProgrammeRoleCode(): ?string
+    {
+        return $this->resourceData[self::PROGRAMME_ROLE_ATTRIBUTE][self::CODE_ATTRIBUTE] ?? null;
+    }
+
+    public function getProgrammeRoleName(): ?array
+    {
+        return $this->resourceData[self::PROGRAMME_ROLE_ATTRIBUTE][self::NAME_ATTRIBUTE][self::VALUE_ATTRIBUTE] ?? null;
+    }
+
+    public function getProgrammeRoleType(): ?string
+    {
+        return $this->resourceData[self::PROGRAMME_ROLE_ATTRIBUTE][self::TYPE_ATTRIBUTE] ?? null;
+    }
+
+    public function getOrder(): ?int
+    {
+        return $this->resourceData[self::ORDER_ATTRIBUTE] ?? null;
+    }
+
+    public function getParentDegreeProgrammeUid(): ?string
+    {
+        return $this->resourceData[self::PARENT_DEGREE_PROGRAMME_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getCurriculumUid(): ?string
+    {
+        return $this->resourceData[self::CURRICULUM_UID_ATTRIBUTE] ?? null;
+    }
+}

--- a/src/PublicRestApi/Studies/PartialStudyResource.php
+++ b/src/PublicRestApi/Studies/PartialStudyResource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+use Dbp\CampusonlineApi\PublicRestApi\Resource;
+
+class PartialStudyResource extends Resource
+{
+    private const PARTIAL_DEGREE_PROGRAMME_UID_ATTRIBUTE = 'partialDegreeProgrammeUid';
+    private const CURRICULUM_VERSION_UID_ATTRIBUTE = 'curriculumVersionUid';
+    private const REGISTRATION_STATUS_TYPE_ATTRIBUTE = 'registrationStatusType';
+
+    public function getUid(): ?string
+    {
+        return $this->resourceData[self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getPartialDegreeProgrammeUid(): ?string
+    {
+        return $this->resourceData[self::PARTIAL_DEGREE_PROGRAMME_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getCurriculumVersionUid(): ?string
+    {
+        return $this->resourceData[self::CURRICULUM_VERSION_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getRegistrationStatusType(): ?string
+    {
+        return $this->resourceData[self::REGISTRATION_STATUS_TYPE_ATTRIBUTE] ?? null;
+    }
+}

--- a/src/PublicRestApi/Studies/StudiesApi.php
+++ b/src/PublicRestApi/Studies/StudiesApi.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+use Dbp\CampusonlineApi\PublicRestApi\AbstractApi;
+
+class StudiesApi extends AbstractApi
+{
+    public const PERSON_UID_QUERY_PARAMETER_NAME = 'person_uid';
+    public const STUDY_UID_QUERY_PARAMETER_NAME = 'study_uid';
+    private const API_PATH = Common::API_PATH.'/studies';
+
+    /**
+     * @return iterable<StudiesResource>
+     */
+    public function getStudies(array $queryParameters = [], array $options = []): iterable
+    {
+        return $this->getResources(
+            self::API_PATH,
+            StudiesResource::class,
+            $queryParameters,
+            $options
+        );
+    }
+
+    /**
+     * @return iterable<StudiesResource>
+     */
+    public function getStudiesByPersonUids(array $personUids, array $options = []): iterable
+    {
+        return $this->getStudies([
+            self::PERSON_UID_QUERY_PARAMETER_NAME => $personUids,
+        ], $options);
+    }
+
+    /**
+     * @return iterable<StudiesResource>
+     */
+    public function getStudiesByStudyUids(array $studyUids, array $options = []): iterable
+    {
+        return $this->getStudies([
+            self::STUDY_UID_QUERY_PARAMETER_NAME => $studyUids,
+        ], $options);
+    }
+
+    public function getStudyByUid(string $studyUid, array $queryParameters = []): StudiesResource
+    {
+        $resource = $this->getResourceByIdentifier(
+            self::API_PATH,
+            StudiesResource::class,
+            $studyUid,
+            $queryParameters
+        );
+        assert($resource instanceof StudiesResource);
+
+        return $resource;
+    }
+}

--- a/src/PublicRestApi/Studies/StudiesResource.php
+++ b/src/PublicRestApi/Studies/StudiesResource.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\PublicRestApi\Studies;
+
+use Dbp\CampusonlineApi\PublicRestApi\Resource;
+
+class StudiesResource extends Resource
+{
+    private const DEGREE_PROGRAMME_UID_ATTRIBUTE = 'degreeProgrammeUid';
+    private const PERSON_UID_ATTRIBUTE = 'personUid';
+    private const CURRICULUM_VERSION_UID_ATTRIBUTE = 'curriculumVersionUid';
+    private const REGISTRATION_STATUS_TYPE_ATTRIBUTE = 'registrationStatusType';
+    private const PARTIAL_STUDIES_ATTRIBUTE = 'partialStudies';
+
+    public function getUid(): ?string
+    {
+        return $this->resourceData[self::UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getDegreeProgrammeUid(): ?string
+    {
+        return $this->resourceData[self::DEGREE_PROGRAMME_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getPersonUid(): ?string
+    {
+        return $this->resourceData[self::PERSON_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getCurriculumVersionUid(): ?string
+    {
+        return $this->resourceData[self::CURRICULUM_VERSION_UID_ATTRIBUTE] ?? null;
+    }
+
+    public function getRegistrationStatusType(): ?string
+    {
+        return $this->resourceData[self::REGISTRATION_STATUS_TYPE_ATTRIBUTE] ?? null;
+    }
+
+    /**
+     * @return PartialStudyResource[]
+     */
+    public function getPartialStudies(): array
+    {
+        $partialStudies = [];
+
+        foreach ($this->resourceData[self::PARTIAL_STUDIES_ATTRIBUTE] ?? [] as $partialStudyData) {
+            if (is_array($partialStudyData)) {
+                $partialStudies[] = new PartialStudyResource($partialStudyData);
+            }
+        }
+
+        return $partialStudies;
+    }
+}

--- a/tests/PublicRestApi/DegreeProgrammeApiTest.php
+++ b/tests/PublicRestApi/DegreeProgrammeApiTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\Tests\PublicRestApi;
+
+use Dbp\CampusonlineApi\PublicRestApi\Connection;
+use Dbp\CampusonlineApi\PublicRestApi\Studies\DegreeProgrammeApi;
+use Dbp\CampusonlineApi\PublicRestApi\Studies\DegreeProgrammeResource;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class DegreeProgrammeApiTest extends TestCase
+{
+    private DegreeProgrammeApi $api;
+
+    /**
+     * @var array<int, array{request: RequestInterface}>
+     */
+    private array $historyContainer = [];
+
+    public const DEGREE_PROGRAMMES_RESPONSE = <<<JSON
+        {
+          "items": [
+            {
+              "uid": "675",
+              "identifier": "UA 057",
+              "curriculumUid": "618",
+              "admissionType": "M",
+              "degreeProgrammeType": "SINGLE",
+              "intendedDegree": {
+                "key": "00",
+                "name": {
+                  "value": {
+                    "de": "Abschluss unbekannt",
+                    "en": "Unknown certificate"
+                  }
+                }
+              },
+              "subject": {
+                "uid": "310",
+                "code": "057",
+                "name": {
+                  "value": {
+                    "de": "Individuelles Diplomstudium",
+                    "en": "Individual diploma programme"
+                  }
+                }
+              },
+              "partialDegreeProgrammes": [
+                {
+                  "uid": "676",
+                  "identifier": "UA 057 001",
+                  "subject": {
+                    "uid": "311",
+                    "code": "001",
+                    "name": {
+                      "value": {
+                        "de": "Teilstudium Beispiel",
+                        "en": "Partial degree programme example"
+                      }
+                    }
+                  },
+                  "programmeRole": {
+                    "uid": "1",
+                    "code": "HF",
+                    "name": {
+                      "value": {
+                        "de": "Hauptfach",
+                        "en": "Major subject"
+                      }
+                    },
+                    "type": "MAJOR"
+                  },
+                  "order": 1,
+                  "parentDegreeProgrammeUid": "675",
+                  "curriculumUid": "619"
+                }
+              ]
+            }
+          ],
+          "limit": 30,
+          "nextCursor": "xxxxxxxx=="
+        }
+        JSON;
+
+    public const DEGREE_PROGRAMME_RESPONSE = <<<JSON
+        {
+          "uid": "675",
+          "identifier": "UA 057",
+          "curriculumUid": "618",
+          "admissionType": "M",
+          "degreeProgrammeType": "SINGLE",
+          "intendedDegree": {
+            "key": "00",
+            "name": {
+              "value": {
+                "de": "Abschluss unbekannt",
+                "en": "Unknown certificate"
+              }
+            }
+          },
+          "subject": {
+            "uid": "310",
+            "code": "057",
+            "name": {
+              "value": {
+                "de": "Individuelles Diplomstudium",
+                "en": "Individual diploma programme"
+              }
+            }
+          },
+          "partialDegreeProgrammes": [
+            {
+              "uid": "676",
+              "identifier": "UA 057 001",
+              "subject": {
+                "uid": "311",
+                "code": "001",
+                "name": {
+                  "value": {
+                    "de": "Teilstudium Beispiel",
+                    "en": "Partial degree programme example"
+                  }
+                }
+              },
+              "programmeRole": {
+                "uid": "1",
+                "code": "HF",
+                "name": {
+                  "value": {
+                    "de": "Hauptfach",
+                    "en": "Major subject"
+                  }
+                },
+                "type": "MAJOR"
+              },
+              "order": 1,
+              "parentDegreeProgrammeUid": "675",
+              "curriculumUid": "619"
+            }
+          ]
+        }
+        JSON;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connection = new Connection('http://invalid', 'clientid', 'secret');
+        $connection->setToken('nope', (new \DateTimeImmutable())->add(new \DateInterval('P1D')));
+
+        $this->api = new DegreeProgrammeApi($connection);
+        $this->mockResponses([]);
+    }
+
+    private function mockResponses(array $responses): void
+    {
+        $this->historyContainer = [];
+        $historyContainer = &$this->historyContainer;
+
+        $stack = HandlerStack::create(new MockHandler($responses));
+        $stack->push(Middleware::history($historyContainer));
+
+        $this->api->setClientHandler($stack);
+    }
+
+    public function testGetDegreeProgrammesByDegreeProgrammeUids(): void
+    {
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json'], self::DEGREE_PROGRAMMES_RESPONSE),
+        ]);
+
+        $result = $this->api->getDegreeProgrammesByDegreeProgrammeUids(['675']);
+        $resources = iterator_to_array($result);
+
+        $this->assertCount(1, $resources);
+        $this->assertRequest(
+            0,
+            '/co/co-sm-core/study/api/degree-programmes',
+            'degree_programme_uid=675'
+        );
+
+        $degreeProgrammeResource = $resources[0];
+        $this->assertDegreeProgrammeResource($degreeProgrammeResource);
+    }
+
+    public function testGetDegreeProgrammeByUid(): void
+    {
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json'], self::DEGREE_PROGRAMME_RESPONSE),
+        ]);
+
+        $degreeProgrammeResource = $this->api->getDegreeProgrammeByUid('675');
+        $this->assertRequest(
+            0,
+            '/co/co-sm-core/study/api/degree-programmes/675'
+        );
+
+        $this->assertDegreeProgrammeResource($degreeProgrammeResource);
+    }
+
+    public function testGetDegreeProgrammesCursorBased(): void
+    {
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json'], self::DEGREE_PROGRAMMES_RESPONSE),
+        ]);
+
+        $result = $this->api->getDegreeProgrammesCursorBased();
+        $resources = iterator_to_array($result->getResources());
+        $this->assertRequest(
+            0,
+            '/co/co-sm-core/study/api/degree-programmes',
+            'limit=30'
+        );
+
+        $this->assertCount(1, $resources);
+        $this->assertSame('xxxxxxxx==', $result->getNextCursor());
+
+        $degreeProgrammeResource = $resources[0];
+        assert($degreeProgrammeResource instanceof DegreeProgrammeResource);
+
+        $this->assertDegreeProgrammeResource($degreeProgrammeResource);
+    }
+
+    private function assertRequest(int $requestIndex, string $expectedPath, string $expectedQuery = ''): void
+    {
+        $this->assertArrayHasKey($requestIndex, $this->historyContainer);
+
+        $request = $this->historyContainer[$requestIndex]['request'];
+
+        $this->assertSame($expectedPath, $request->getUri()->getPath());
+        $this->assertSame($expectedQuery, $request->getUri()->getQuery());
+    }
+
+    private function assertDegreeProgrammeResource(DegreeProgrammeResource $degreeProgrammeResource): void
+    {
+        $this->assertSame('675', $degreeProgrammeResource->getUid());
+        $this->assertSame('UA 057', $degreeProgrammeResource->getIdentifier());
+        $this->assertSame('618', $degreeProgrammeResource->getCurriculumUid());
+        $this->assertSame('M', $degreeProgrammeResource->getAdmissionType());
+        $this->assertSame('SINGLE', $degreeProgrammeResource->getDegreeProgrammeType());
+        $this->assertSame('00', $degreeProgrammeResource->getIntendedDegreeKey());
+        $this->assertSame([
+            'de' => 'Abschluss unbekannt',
+            'en' => 'Unknown certificate',
+        ], $degreeProgrammeResource->getIntendedDegreeName());
+        $this->assertSame('310', $degreeProgrammeResource->getSubjectUid());
+        $this->assertSame('057', $degreeProgrammeResource->getSubjectCode());
+        $this->assertSame([
+            'de' => 'Individuelles Diplomstudium',
+            'en' => 'Individual diploma programme',
+        ], $degreeProgrammeResource->getSubjectName());
+
+        $partialDegreeProgrammes = $degreeProgrammeResource->getPartialDegreeProgrammes();
+
+        $this->assertCount(1, $partialDegreeProgrammes);
+
+        $partialDegreeProgrammeResource = $partialDegreeProgrammes[0];
+
+        $this->assertSame('676', $partialDegreeProgrammeResource->getUid());
+        $this->assertSame('UA 057 001', $partialDegreeProgrammeResource->getIdentifier());
+        $this->assertSame('311', $partialDegreeProgrammeResource->getSubjectUid());
+        $this->assertSame('001', $partialDegreeProgrammeResource->getSubjectCode());
+        $this->assertSame([
+            'de' => 'Teilstudium Beispiel',
+            'en' => 'Partial degree programme example',
+        ], $partialDegreeProgrammeResource->getSubjectName());
+        $this->assertSame('1', $partialDegreeProgrammeResource->getProgrammeRoleUid());
+        $this->assertSame('HF', $partialDegreeProgrammeResource->getProgrammeRoleCode());
+        $this->assertSame([
+            'de' => 'Hauptfach',
+            'en' => 'Major subject',
+        ], $partialDegreeProgrammeResource->getProgrammeRoleName());
+        $this->assertSame('MAJOR', $partialDegreeProgrammeResource->getProgrammeRoleType());
+        $this->assertSame(1, $partialDegreeProgrammeResource->getOrder());
+        $this->assertSame('675', $partialDegreeProgrammeResource->getParentDegreeProgrammeUid());
+        $this->assertSame('619', $partialDegreeProgrammeResource->getCurriculumUid());
+    }
+}

--- a/tests/PublicRestApi/StudiesApiTest.php
+++ b/tests/PublicRestApi/StudiesApiTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dbp\CampusonlineApi\Tests\PublicRestApi;
+
+use Dbp\CampusonlineApi\PublicRestApi\Connection;
+use Dbp\CampusonlineApi\PublicRestApi\Studies\StudiesApi;
+use Dbp\CampusonlineApi\PublicRestApi\Studies\StudiesResource;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class StudiesApiTest extends TestCase
+{
+    private StudiesApi $api;
+    /**
+     * @var array<int, array{request: \Psr\Http\Message\RequestInterface}>
+     */
+    private array $historyContainer = [];
+    public const STUDIES_RESPONSE = <<<JSON
+        {
+          "items": [
+            {
+              "uid": "195685",
+              "degreeProgrammeUid": "675",
+              "personUid": "B0A1EB6E192CB00E",
+              "curriculumVersionUid": "618",
+              "registrationStatusType": "Z",
+              "partialStudies": [
+                {
+                  "uid": "195686",
+                  "partialDegreeProgrammeUid": "676",
+                  "curriculumVersionUid": "619",
+                  "registrationStatusType": "I"
+                }
+              ]
+            }
+          ]
+        }
+        JSON;
+
+    public const STUDY_RESPONSE = <<<JSON
+        {
+          "uid": "195685",
+          "degreeProgrammeUid": "675",
+          "personUid": "B0A1EB6E192CB00E",
+          "curriculumVersionUid": "618",
+          "registrationStatusType": "Z",
+          "partialStudies": [
+            {
+              "uid": "195686",
+              "partialDegreeProgrammeUid": "676",
+              "curriculumVersionUid": "619",
+              "registrationStatusType": "I"
+            }
+          ]
+        }
+        JSON;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connection = new Connection('http://invalid', 'clientid', 'secret');
+        $connection->setToken('nope', (new \DateTimeImmutable())->add(new \DateInterval('P1D')));
+
+        $this->api = new StudiesApi($connection);
+        $this->mockResponses([]);
+    }
+
+    private function mockResponses(array $responses): void
+    {
+        $this->historyContainer = [];
+        $historyContainer = &$this->historyContainer;
+
+        $stack = HandlerStack::create(new MockHandler($responses));
+        $stack->push(Middleware::history($historyContainer));
+
+        $this->api->setClientHandler($stack);
+    }
+
+    public function testGetStudiesByPersonUids(): void
+    {
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json'], self::STUDIES_RESPONSE),
+        ]);
+
+        $result = $this->api->getStudiesByPersonUids(['B0A1EB6E192CB00E']);
+        $resources = iterator_to_array($result);
+
+        $this->assertRequest(
+            0,
+            '/co/co-sm-core/study/api/studies',
+            'person_uid=B0A1EB6E192CB00E'
+        );
+        $this->assertCount(1, $resources);
+
+        $studiesResource = $resources[0];
+        $this->assertStudiesResource($studiesResource);
+    }
+
+    public function testGetStudiesByStudyUids(): void
+    {
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json'], self::STUDIES_RESPONSE),
+        ]);
+
+        $result = $this->api->getStudiesByStudyUids(['195685']);
+        $resources = iterator_to_array($result);
+
+        $this->assertCount(1, $resources);
+
+        $studiesResource = $resources[0];
+
+        $this->assertStudiesResource($studiesResource);
+    }
+
+    public function testGetStudyByUid(): void
+    {
+        $this->mockResponses([
+            new Response(200, ['Content-Type' => 'application/json'], self::STUDY_RESPONSE),
+        ]);
+
+        $studiesResource = $this->api->getStudyByUid('195685');
+        $this->assertRequest(
+            0,
+            '/co/co-sm-core/study/api/studies/195685'
+        );
+
+        $this->assertStudiesResource($studiesResource);
+    }
+
+    private function assertStudiesResource(StudiesResource $studiesResource): void
+    {
+        $this->assertSame('195685', $studiesResource->getUid());
+        $this->assertSame('675', $studiesResource->getDegreeProgrammeUid());
+        $this->assertSame('B0A1EB6E192CB00E', $studiesResource->getPersonUid());
+        $this->assertSame('618', $studiesResource->getCurriculumVersionUid());
+        $this->assertSame('Z', $studiesResource->getRegistrationStatusType());
+
+        $partialStudies = $studiesResource->getPartialStudies();
+
+        $this->assertCount(1, $partialStudies);
+
+        $partialStudyResource = $partialStudies[0];
+
+        $this->assertSame('195686', $partialStudyResource->getUid());
+        $this->assertSame('676', $partialStudyResource->getPartialDegreeProgrammeUid());
+        $this->assertSame('619', $partialStudyResource->getCurriculumVersionUid());
+        $this->assertSame('I', $partialStudyResource->getRegistrationStatusType());
+    }
+
+    private function assertRequest(int $requestIndex, string $expectedPath, string $expectedQuery = ''): void
+    {
+        $this->assertArrayHasKey($requestIndex, $this->historyContainer);
+
+        $request = $this->historyContainer[$requestIndex]['request'];
+
+        $this->assertSame($expectedPath, $request->getUri()->getPath());
+        $this->assertSame($expectedQuery, $request->getUri()->getQuery());
+    }
+}


### PR DESCRIPTION
This PR adds wrappers for the CAMPUSonline Study public REST API
This is a _draft_ because the downstream display/filtering rules for study statuses still need some clarification
The API wrapper itself  does not apply any status filtering _(that's intentional)_

## changes:

- Added `StudiesApi` for `/studies`
- Added `StudiesResource` and `PartialStudyResource`
- Added `DegreeProgrammeApi` for `/degree-programmes`
- Added `DegreeProgrammeResource` and `PartialDegreeProgrammeResource`
- Added PHPUnit tests for studies and degree programmes
- Added request path/query assertions using Guzzle history middleware

## reason:

`/studies` exposes the personal studies of a person and includes `registrationStatusType`

The related degree programme data is exposed through `/degree-programmes`, because the study resources only contain `degreeProgrammeUid` / `partialDegreeProgrammeUid`, while display-relevant data such as `identifier`, `intendedDegree` and `subject` comes from the degree programme resources

No status-based filtering is implemented in this API wrapper
The status is exposed to callers, so the consuming layer can decide which studies should be displayed _(once the relevant statuses have been clarified)_

## verification

- `vendor/bin/phpunit tests/PublicRestApi/StudiesApiTest.php`
- `vendor/bin/phpunit tests/PublicRestApi/DegreeProgrammeApiTest.php`
- `composer phpstan`
- `composer test`
- `composer cs`